### PR TITLE
Fix bug in assertion.

### DIFF
--- a/DBN/rbmtrain.m
+++ b/DBN/rbmtrain.m
@@ -1,6 +1,6 @@
 function rbm = rbmtrain(rbm, x, opts)
     assert(isfloat(x), 'x must be a float');
-    assert(all(x>=0) && all(x<=1), 'all data in x must be in [0:1]');
+    assert(all(all(x>=0)) && all(all(x<=1)), 'all data in x must be in [0:1]');
     m = size(x, 1);
     numbatches = m / opts.batchsize;
     


### PR DESCRIPTION
Forked the repo today. Trying out the DBN example gave an error. I figured out it was because all(x>=0) returns an array of boolean values when you hand it a matrix. So all(all(x>=0)) return whether all the values is above or equal to zero.
