### PR TITLE
Added feature to allow different learning rates per layer in the NN 

### DIFF
--- a/NN/nnapplygrads.m
+++ b/NN/nnapplygrads.m
@@ -10,7 +10,12 @@ function nn = nnapplygrads(nn)
             dW = nn.dW{i};
         end
         
-        dW = nn.learningRate * dW;
+        % to apply different learning rates to each layer
+        if isempty(nn.learningRatePerLayer)
+            dW = nn.learningRate * dW;
+        else
+            dW = nn.learningRatePerLayer(i) * dW;
+        end
         
         if(nn.momentum>0)
             nn.vW{i} = nn.momentum*nn.vW{i} + dW;

--- a/NN/nnsetup.m
+++ b/NN/nnsetup.m
@@ -8,6 +8,7 @@ function nn = nnsetup(architecture)
     
     nn.activation_function              = 'tanh_opt';   %  Activation functions of hidden layers: 'sigm' (sigmoid) or 'tanh_opt' (optimal tanh).
     nn.learningRate                     = 2;            %  learning rate Note: typically needs to be lower when using 'sigm' activation function and non-normalized inputs.
+    nn.learningRatePerLayer             = [];           %  learning rate per layer - for transfer learning pre-training and fine-tuning different parts of the network (should be of length nn.n - 1)
     nn.momentum                         = 0.5;          %  Momentum
     nn.scaling_learningRate             = 1;            %  Scaling factor for the learning rate (each epoch)
     nn.weightPenaltyL2                  = 0;            %  L2 regularization

--- a/NN/nntrain.m
+++ b/NN/nntrain.m
@@ -72,7 +72,9 @@ for i = 1 : numepochs
         
     disp(['epoch ' num2str(i) '/' num2str(opts.numepochs) '. Took ' num2str(t) ' seconds' '. Mini-batch mean squared error on training set is ' num2str(mean(L((n-numbatches):(n-1)))) str_perf]);
     nn.learningRate = nn.learningRate * nn.scaling_learningRate;
-    nn.learningRatePerLayer = nn.learningRatePerLayer * nn.scaling_learningRate;
+    if ~isempty(nn.learningRatePerLayer)
+        nn.learningRatePerLayer = nn.learningRatePerLayer * nn.scaling_learningRate;
+    end
 end
 end
 

--- a/NN/nntrain.m
+++ b/NN/nntrain.m
@@ -72,6 +72,7 @@ for i = 1 : numepochs
         
     disp(['epoch ' num2str(i) '/' num2str(opts.numepochs) '. Took ' num2str(t) ' seconds' '. Mini-batch mean squared error on training set is ' num2str(mean(L((n-numbatches):(n-1)))) str_perf]);
     nn.learningRate = nn.learningRate * nn.scaling_learningRate;
+    nn.learningRatePerLayer = nn.learningRatePerLayer * nn.scaling_learningRate;
 end
 end
 


### PR DESCRIPTION
Added feature to allow different learning rates per layer in the NN. This feature is useful for transfer learning where you pre-training parts of the NN and then fine-tuning additional layers on top. The learning rates should be higher for the new layers and lower for the pre-trained layers. This is similar to what was done here: http://caffe.berkeleyvision.org/gathered/examples/finetune_flickr_style.html

By default the nn.learningRatePerLayer=[] and this will not cause an error in the default case as I check to see if its empty. The changes are very simple and straight forward.