### PR TITLE
Handle single-matrix inputs correctly

### DIFF
--- a/CNN/cnnff.m
+++ b/CNN/cnnff.m
@@ -8,7 +8,7 @@ function net = cnnff(net, x)
             %  !!below can probably be handled by insane matrix operations
             for j = 1 : net.layers{l}.outputmaps   %  for each output map
                 %  create temp output map
-                z = zeros(size(net.layers{l - 1}.a{1}) - [net.layers{l}.kernelsize - 1 net.layers{l}.kernelsize - 1 0]);
+	    z = zeros(postpad(size(net.layers{l - 1}.a{1}), 3, 1) - [net.layers{l}.kernelsize - 1 net.layers{l}.kernelsize - 1 0]);
                 for i = 1 : inputmaps   %  for each input map
                     %  convolve with corresponding kernel and add to temp output map
                     z = z + convn(net.layers{l - 1}.a{i}, net.layers{l}.k{i}{j}, 'valid');
@@ -30,7 +30,7 @@ function net = cnnff(net, x)
     %  concatenate all end layer feature maps into vector
     net.fv = [];
     for j = 1 : numel(net.layers{n}.a)
-        sa = size(net.layers{n}.a{j});
+	sa = postpad(size(net.layers{n}.a{j}), 3, 1);
         net.fv = [net.fv; reshape(net.layers{n}.a{j}, sa(1) * sa(2), sa(3))];
     end
     %  feedforward into output perceptrons


### PR DESCRIPTION
When feeding a single matrix of inputs to cnnff, i.e. running "live data" through a network that has already been trained, the size() command drops the third parameter in its result because the input looks like two-dimensional data rather than a single instance of three-dimensional data. This missing parameter then triggers an error.

Adding postpad() forces the third parameter to a '1' if size() doesn't provide a different value.
